### PR TITLE
markdown-service: add support for numbered lists

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -61,7 +61,9 @@ const MarkdownService = require('../lib/markdown-service.js'),
         'I know how easy it is do nothing because I did nothing for too long. Take a good look at the data, educate yourself and talk to the patients, who are often out of options and find their hope in the form of a simple plant.',
         'Journalists shouldn\'t take a position. It makes sense. Objectivity is king. But, at some point, open questions do get answered. At some point, contentious issues do get resolved. At some point, common sense prevails.',
         'So, here it is: We should legalize medical marijuana. We should do it nationally. And, we should do it now.',
-        '<a href="http://money.cnn.com/2015/04/13/news/pot-marijuana-facts/" target="_blank">9 things to know about legal pot</a>'
+        '<a href="http://money.cnn.com/2015/04/13/news/pot-marijuana-facts/" target="_blank">9 things to know about legal pot</a>',
+        '2. "Hillary Clinton as you know, as most people know, she\'s a world class liar."',
+        '12. "Hillary Clinton as you know, as most people know, she\'s a world class liar."'
     ];
 
 paragraphs.forEach((paragraph) => {

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -65,6 +65,10 @@ class MarkdownService {
             data = data.replace(/\*/, '\\*');
             data = data.replace(/<strong>|<\/strong>/g, '**');
 
+            // add escape for numbered lists
+            // https://regex101.com/r/nB8bV3/1
+            data = data.replace(/(^\d{1,2})(. )/, '$1\\\\. ');
+
             if (data.match(/<a.*>|<\/a>/)) {
                 // https://regex101.com/r/zQ7rD3/2
                 data = data.replace(/<a.+?href="(.+?)".*?>(.+?)<\/a>/g, (match, p1, p2) => {

--- a/test/unit/markdown-service-test.js
+++ b/test/unit/markdown-service-test.js
@@ -278,6 +278,20 @@ describe('Markdown Service', () => {
         response.should.equal(expectedResponse);
     });
 
+    it('should convert single digit numbered lists to add \\\\ between the digit and the digit\'s "."', () => {
+        const response = this.markdownService.format('1. Foo'),
+            expectedResponse = '1\\\\. Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should convert double digit numbered lists to add \\\\ between the digit and the digit\'s "."', () => {
+        const response = this.markdownService.format('11. Foo'),
+            expectedResponse = '11\\\\. Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
     it('should return what was passed in if it is not a string, like an array', () => {
         const response = this.markdownService.format(['foo', 'bar']),
             expectedResponse = ['foo', 'bar'];


### PR DESCRIPTION
When content contains a numbered list, a condition could exist that
would cause the list to render as all numeral one.

Fixes: Add Number List Support
Reviewed-By: Katie Owen (katherine.owen@turner.com)
