### PR TITLE
markdown-service: update ordered lists

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -63,7 +63,13 @@ const MarkdownService = require('../lib/markdown-service.js'),
         'So, here it is: We should legalize medical marijuana. We should do it nationally. And, we should do it now.',
         '<a href="http://money.cnn.com/2015/04/13/news/pot-marijuana-facts/" target="_blank">9 things to know about legal pot</a>',
         '2. "Hillary Clinton as you know, as most people know, she\'s a world class liar."',
-        '12. "Hillary Clinton as you know, as most people know, she\'s a world class liar."'
+        '12. "Hillary Clinton as you know, as most people know, she\'s a world class liar."',
+        '123. "Hillary Clinton as you know, as most people know, she\'s a world class liar."',
+        '124. "Hillary Clinton as you know, as most people know, she\'s a world class liar."',
+        '1 presidential candidates speak out on gay marriage ruling',
+        '12 presidential candidates speak out on gay marriage ruling',
+        '123 presidential candidates speak out on gay marriage ruling',
+        '1234 presidential candidates speak out on gay marriage ruling'
     ];
 
 paragraphs.forEach((paragraph) => {

--- a/example/example.js
+++ b/example/example.js
@@ -69,7 +69,7 @@ const MarkdownService = require('../lib/markdown-service.js'),
         '1 presidential candidates speak out on gay marriage ruling',
         '12 presidential candidates speak out on gay marriage ruling',
         '123 presidential candidates speak out on gay marriage ruling',
-        '1234 presidential candidates speak out on gay marriage ruling'
+        '1234 presidential candidates speak out on gay marriage ruling',
         '<del>Kristina Sivkova (4x100m)</del>'
     ];
 

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -67,7 +67,9 @@ class MarkdownService {
 
             // add escape for numbered lists
             // https://regex101.com/r/nB8bV3/2
-            data = data.replace(/(^\d{1,2})(.?)/, '$1\\.');
+            if (data.match(/^\d{1,2}./)) {
+                data = data.replace(/(^\d{1,2})(.)/, '$1\\$2');
+            }
 
             if (data.match(/<a.*>|<\/a>/)) {
                 // https://regex101.com/r/zQ7rD3/2

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -67,7 +67,7 @@ class MarkdownService {
 
             // add escape for numbered lists
             // https://regex101.com/r/nB8bV3/1
-            data = data.replace(/(^\d{1,2})(. )/, '$1\\. ');
+            data = data.replace(/(^\d{1,2})(. )/, '$1\\\\. ');
 
             if (data.match(/<a.*>|<\/a>/)) {
                 // https://regex101.com/r/zQ7rD3/2

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -66,8 +66,8 @@ class MarkdownService {
             data = data.replace(/<strong>|<\/strong>/g, '**');
 
             // add escape for numbered lists
-            // https://regex101.com/r/nB8bV3/1
-            data = data.replace(/(^\d{1,2})(. )/, '$1\\.');
+            // https://regex101.com/r/nB8bV3/2
+            data = data.replace(/(^\d{1,2})(.?)/, '$1\\.');
 
             if (data.match(/<a.*>|<\/a>/)) {
                 // https://regex101.com/r/zQ7rD3/2

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -67,7 +67,7 @@ class MarkdownService {
 
             // add escape for numbered lists
             // https://regex101.com/r/nB8bV3/2
-            if (data.match(/^\d{1,2}./)) {
+            if (data.match(/^\d{1,2}[.]/)) {
                 data = data.replace(/(^\d{1,2})(.)/, '$1\\$2');
             }
 

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -67,7 +67,7 @@ class MarkdownService {
 
             // add escape for numbered lists
             // https://regex101.com/r/nB8bV3/1
-            data = data.replace(/(^\d{1,2})(. )/, '$1\\\\. ');
+            data = data.replace(/(^\d{1,2})(. )/, '$1\\. ');
 
             if (data.match(/<a.*>|<\/a>/)) {
                 // https://regex101.com/r/zQ7rD3/2

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -66,9 +66,10 @@ class MarkdownService {
             data = data.replace(/<strong>|<\/strong>/g, '**');
 
             // add escape for numbered lists
-            // https://regex101.com/r/nB8bV3/2
-            if (data.match(/^\d{1,2}[.]/)) {
-                data = data.replace(/(^\d{1,2})(.)/, '$1\\$2');
+            // https://regex101.com/r/SO5haw/1
+            if (data.match(/^\d{1,4}\./)) {
+                // https://regex101.com/r/nB8bV3/4
+                data = data.replace(/(^\d{1,4})(.)/, '$1\\$2');
             }
 
             if (data.match(/<a.*>|<\/a>/)) {

--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -67,7 +67,7 @@ class MarkdownService {
 
             // add escape for numbered lists
             // https://regex101.com/r/nB8bV3/1
-            data = data.replace(/(^\d{1,2})(. )/, '$1\\\\. ');
+            data = data.replace(/(^\d{1,2})(. )/, '$1\\.');
 
             if (data.match(/<a.*>|<\/a>/)) {
                 // https://regex101.com/r/zQ7rD3/2

--- a/test/unit/markdown-service-test.js
+++ b/test/unit/markdown-service-test.js
@@ -286,8 +286,57 @@ describe('Markdown Service', () => {
     });
 
     it('should convert double digit numbered lists to add \\\\ between the digit and the digit\'s "."', () => {
-        const response = this.markdownService.format('11. Foo'),
-            expectedResponse = '11\\. Foo';
+        const response = this.markdownService.format('12. Foo'),
+            expectedResponse = '12\\. Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should convert a triple digit numbered lists to add \\\\ between the digit and the digit\'s "."', () => {
+        const response = this.markdownService.format('123. Foo'),
+            expectedResponse = '123\\. Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should convert a four digit numbered lists to add \\\\ between the digit and the digit\'s "."', () => {
+        const response = this.markdownService.format('1234. Foo'),
+            expectedResponse = '1234\\. Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should not alter a string with a single digit number that is not a numbered list', () => {
+        const response = this.markdownService.format('1 Foo'),
+            expectedResponse = '1 Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should not alter a string with a double digit number that is not a numbered list', () => {
+        const response = this.markdownService.format('12 Foo'),
+            expectedResponse = '12 Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should not alter a string with a tripel digit number that is not a numbered list', () => {
+        const response = this.markdownService.format('123 Foo'),
+            expectedResponse = '123 Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should not alter a string with a four digit number that is not a numbered list', () => {
+        const response = this.markdownService.format('1234 Foo'),
+            expectedResponse = '1234 Foo';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should not alter a string with a four digit number at end that is not a numbered list', () => {
+        const response = this.markdownService.format('Foo 1234'),
+            expectedResponse = 'Foo 1234';
 
         response.should.equal(expectedResponse);
     });

--- a/test/unit/markdown-service-test.js
+++ b/test/unit/markdown-service-test.js
@@ -280,14 +280,14 @@ describe('Markdown Service', () => {
 
     it('should convert single digit numbered lists to add \\\\ between the digit and the digit\'s "."', () => {
         const response = this.markdownService.format('1. Foo'),
-            expectedResponse = '1\\\\. Foo';
+            expectedResponse = '1\\. Foo';
 
         response.should.equal(expectedResponse);
     });
 
     it('should convert double digit numbered lists to add \\\\ between the digit and the digit\'s "."', () => {
         const response = this.markdownService.format('11. Foo'),
-            expectedResponse = '11\\\\. Foo';
+            expectedResponse = '11\\. Foo';
 
         response.should.equal(expectedResponse);
     });


### PR DESCRIPTION
An update is needed to add markdown processing to numbered lists that will exclude numbers not meant to be in a list.


Reviewed-By: Katie Owen <katherine.owen@turner.com>