### PR TITLE
CNNAPPNEWS-3  fixing issue where href urls containing unencoded single quotes are b…

### DIFF
--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -75,6 +75,8 @@ class MarkdownService {
                 data = data.replace(/<a.+?href="(.+?)".*?>(.+?)<\/a>/g, (match, p1, p2) => {
                     // encode spaces in urls
                     p1 = p1.replace(/\s+/g, '%20');
+                    // encode single quotes in urls
+                    p1 = p1.replace(/'/g, '%27');
 
                     return `[${p2}](${p1})`;
                 });

--- a/test/unit/markdown-service-test.js
+++ b/test/unit/markdown-service-test.js
@@ -236,6 +236,13 @@ describe('Markdown Service', () => {
         response.should.equal(expectedResponse);
     });
 
+    it('should encode  <a> tags with href urls containing un-encoded single quotes ', () => {
+        const response = this.markdownService.format('<a style="foo" href="https://books.google.com/books?id=0Jm9C06fLFYC&pg=PT44&lpg=PT44&dq=no+one+who+knew+the+president+ever+quite+understood+Chevy+Chase%27s+Saturday+Night+Live+impersonation+of+him+as+a+genial+dolt+who+stumbled+over+doorsteps+and+big+words.+Unfortunately,+the+caricature+--+particularly+the+physical+humor+--+took+on+a+life+of+its+own&source=bl&ots=BH77cAn57_&sig=iRqinzda_s1rcEuNejTPZ2EZlOg&hl=en&sa=X&ved=0ahUKEwjR2P67p4rPAhUEJiYKHeMfAfcQ6AEIITAB#v=onepage&q=no%20one%20who%20knew%20the%20president%20ever%20quite%20understood%20Chevy%20Chase\'s%20Saturday%20Night%20Live%20impersonation%20of%20him%20as%20a%20genial%20dolt%20who%20stumbled%20over%20doorsteps%20and%20big%20words.%20Unfortunately%2C%20the%20caricature%20--%20particularly%20the%20physical%20humor%20--%20took%20on%20a%20life%20of%20its%20own&f=false" target="_blank">According to James Baker</a>'),
+            expectedResponse = '[According to James Baker](https://books.google.com/books?id=0Jm9C06fLFYC&pg=PT44&lpg=PT44&dq=no+one+who+knew+the+president+ever+quite+understood+Chevy+Chase%27s+Saturday+Night+Live+impersonation+of+him+as+a+genial+dolt+who+stumbled+over+doorsteps+and+big+words.+Unfortunately,+the+caricature+--+particularly+the+physical+humor+--+took+on+a+life+of+its+own&source=bl&ots=BH77cAn57_&sig=iRqinzda_s1rcEuNejTPZ2EZlOg&hl=en&sa=X&ved=0ahUKEwjR2P67p4rPAhUEJiYKHeMfAfcQ6AEIITAB#v=onepage&q=no%20one%20who%20knew%20the%20president%20ever%20quite%20understood%20Chevy%20Chase%27s%20Saturday%20Night%20Live%20impersonation%20of%20him%20as%20a%20genial%20dolt%20who%20stumbled%20over%20doorsteps%20and%20big%20words.%20Unfortunately%2C%20the%20caricature%20--%20particularly%20the%20physical%20humor%20--%20took%20on%20a%20life%20of%20its%20own&f=false)';
+
+        response.should.equal(expectedResponse);
+    });
+
     it('should convert <h1> tags to prepend a hash (#) before the string', () => {
         const response = this.markdownService.format('<h1>Foo</h1>'),
             expectedResponse = '# Foo';


### PR DESCRIPTION
Markdown Service: encode single quotes in HREF URL.

Fixes: CNNAPPNEWS-3

PR_URL:

Review-By: Sean Joseph sean.joseph@turner
Review-By: James Young james.young@turner