### PR TITLE
[CNNAPPNEWS-165]: Added fix to encode parentheses in urls

### DIFF
--- a/lib/markdown-service.js
+++ b/lib/markdown-service.js
@@ -80,6 +80,9 @@ class MarkdownService {
                     p1 = p1.replace(/\s+/g, '%20');
                     // encode single quotes in urls
                     p1 = p1.replace(/'/g, '%27');
+                    // encode parentheses in urls
+                    p1 = p1.replace(/\(/g, '%28');
+                    p1 = p1.replace(/\)/g, '%29');
 
                     return `[${p2}](${p1})`;
                 });

--- a/test/unit/markdown-service-test.js
+++ b/test/unit/markdown-service-test.js
@@ -236,9 +236,16 @@ describe('Markdown Service', () => {
         response.should.equal(expectedResponse);
     });
 
-    it('should encode  <a> tags with href urls containing un-encoded single quotes ', () => {
+    it('should encode <a> tags with href urls containing un-encoded single quotes', () => {
         const response = this.markdownService.format('<a style="foo" href="https://books.google.com/books?id=0Jm9C06fLFYC&pg=PT44&lpg=PT44&dq=no+one+who+knew+the+president+ever+quite+understood+Chevy+Chase%27s+Saturday+Night+Live+impersonation+of+him+as+a+genial+dolt+who+stumbled+over+doorsteps+and+big+words.+Unfortunately,+the+caricature+--+particularly+the+physical+humor+--+took+on+a+life+of+its+own&source=bl&ots=BH77cAn57_&sig=iRqinzda_s1rcEuNejTPZ2EZlOg&hl=en&sa=X&ved=0ahUKEwjR2P67p4rPAhUEJiYKHeMfAfcQ6AEIITAB#v=onepage&q=no%20one%20who%20knew%20the%20president%20ever%20quite%20understood%20Chevy%20Chase\'s%20Saturday%20Night%20Live%20impersonation%20of%20him%20as%20a%20genial%20dolt%20who%20stumbled%20over%20doorsteps%20and%20big%20words.%20Unfortunately%2C%20the%20caricature%20--%20particularly%20the%20physical%20humor%20--%20took%20on%20a%20life%20of%20its%20own&f=false" target="_blank">According to James Baker</a>'),
             expectedResponse = '[According to James Baker](https://books.google.com/books?id=0Jm9C06fLFYC&pg=PT44&lpg=PT44&dq=no+one+who+knew+the+president+ever+quite+understood+Chevy+Chase%27s+Saturday+Night+Live+impersonation+of+him+as+a+genial+dolt+who+stumbled+over+doorsteps+and+big+words.+Unfortunately,+the+caricature+--+particularly+the+physical+humor+--+took+on+a+life+of+its+own&source=bl&ots=BH77cAn57_&sig=iRqinzda_s1rcEuNejTPZ2EZlOg&hl=en&sa=X&ved=0ahUKEwjR2P67p4rPAhUEJiYKHeMfAfcQ6AEIITAB#v=onepage&q=no%20one%20who%20knew%20the%20president%20ever%20quite%20understood%20Chevy%20Chase%27s%20Saturday%20Night%20Live%20impersonation%20of%20him%20as%20a%20genial%20dolt%20who%20stumbled%20over%20doorsteps%20and%20big%20words.%20Unfortunately%2C%20the%20caricature%20--%20particularly%20the%20physical%20humor%20--%20took%20on%20a%20life%20of%20its%20own&f=false)';
+
+        response.should.equal(expectedResponse);
+    });
+
+    it('should encode <a> tags with href urls containing un-encoded parentheses', () => {
+        const response = this.markdownService.format('<a style="foo" href="http://www.thelancet.com/journals/langas/article/PIIS2468-1253(16)30026-7/fulltext" target="_blank">study</a>'),
+            expectedResponse = '[study](http://www.thelancet.com/journals/langas/article/PIIS2468-1253%2816%2930026-7/fulltext)';
 
         response.should.equal(expectedResponse);
     });


### PR DESCRIPTION
Fixes the problem with parens () in the URL

Example:
`<a href="http://www.thelancet.com/journals/langas/article/PIIS2468-1253(16)30026-7/fulltext" target="_blank">study</a>`